### PR TITLE
Resolve send promises via confirmChannel callback

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -301,24 +301,31 @@ var Message = (function () {
         if (routingKey === void 0) { routingKey = ""; }
         // inline function to send the message
         var sendMessage = function () {
-            try {
-                destination._channel.publish(exchange, routingKey, _this.content, _this.properties);
-            }
-            catch (err) {
+            return new Promise(function (resolve, reject) {
+                destination._channel.publish(exchange, routingKey, _this.content, _this.properties, function (err, data) {
+                    if (!err) {
+                        resolve(data);
+                    }
+                    else {
+                        reject(err);
+                    }
+                });
+            })
+                .catch(function (err) {
                 exports.log.log("debug", "Publish error: " + err.message, { module: "amqp-ts" });
                 var destinationName = destination._name;
                 var connection = destination._connection;
                 exports.log.log("debug", "Try to rebuild connection, before Call.", { module: "amqp-ts" });
-                connection._rebuildAll(err).then(function () {
+                return connection._rebuildAll(err).then(function () {
                     exports.log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
                     if (destination instanceof Queue) {
-                        connection._queues[destinationName].publish(_this.content, _this.properties);
+                        return connection._queues[destinationName].publish(_this.content, _this.properties);
                     }
                     else {
-                        connection._exchanges[destinationName].publish(_this.content, routingKey, _this.properties);
+                        return connection._exchanges[destinationName].publish(_this.content, routingKey, _this.properties);
                     }
                 });
-            }
+            });
         };
         var exchange;
         if (destination instanceof Queue) {
@@ -330,10 +337,10 @@ var Message = (function () {
         }
         // execute sync when possible
         if (destination.initialized.isFulfilled()) {
-            sendMessage();
+            return sendMessage();
         }
         else {
-            destination.initialized.then(sendMessage);
+            return destination.initialized.then(sendMessage);
         }
     };
     Message.prototype.ack = function (allUpTo) {
@@ -385,7 +392,7 @@ var Exchange = (function () {
         var _this = this;
         this.initialized = new Promise(function (resolve, reject) {
             _this._connection.initialized.then(function () {
-                _this._connection._connection.createChannel(function (err, channel) {
+                _this._connection._connection.createConfirmChannel(function (err, channel) {
                     /* istanbul ignore if */
                     if (err) {
                         reject(err);
@@ -429,24 +436,30 @@ var Exchange = (function () {
             content = new Buffer(JSON.stringify(content));
             options.contentType = options.contentType || "application/json";
         }
-        this.initialized.then(function () {
-            try {
-                _this._channel.publish(_this._name, routingKey, content, options);
-            }
-            catch (err) {
+        return this.initialized.then(function () {
+            return new Promise(function (resolve, reject) {
+                _this._channel.publish(_this._name, routingKey, content, options, function (err, data) {
+                    if (!err) {
+                        resolve(data);
+                    }
+                    else {
+                        reject(err);
+                    }
+                });
+            }).catch(function (err) {
                 exports.log.log("warn", "Exchange publish error: " + err.message, { module: "amqp-ts" });
                 var exchangeName = _this._name;
                 var connection = _this._connection;
-                connection._rebuildAll(err).then(function () {
+                return connection._rebuildAll(err).then(function () {
                     exports.log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
-                    connection._exchanges[exchangeName].publish(content, routingKey, options);
+                    return connection._exchanges[exchangeName].publish(content, routingKey, options);
                 });
-            }
+            });
         });
     };
     Exchange.prototype.send = function (message, routingKey) {
         if (routingKey === void 0) { routingKey = ""; }
-        message.sendTo(this, routingKey);
+        return message.sendTo(this, routingKey);
     };
     Exchange.prototype.rpc = function (requestParameters, routingKey) {
         var _this = this;
@@ -635,7 +648,7 @@ var Queue = (function () {
         var _this = this;
         this.initialized = new Promise(function (resolve, reject) {
             _this._connection.initialized.then(function () {
-                _this._connection._connection.createChannel(function (err, channel) {
+                _this._connection._connection.createConfirmChannel(function (err, channel) {
                     /* istanbul ignore if */
                     if (err) {
                         reject(err);
@@ -692,27 +705,33 @@ var Queue = (function () {
         if (options === void 0) { options = {}; }
         // inline function to send the message
         var sendMessage = function () {
-            try {
-                _this._channel.sendToQueue(_this._name, content, options);
-            }
-            catch (err) {
+            return new Promise(function (resolve, reject) {
+                _this._channel.sendToQueue(_this._name, content, options, function (err, data) {
+                    if (!err) {
+                        resolve(data);
+                    }
+                    else {
+                        reject(err);
+                    }
+                });
+            }).catch(function (err) {
                 exports.log.log("debug", "Queue publish error: " + err.message, { module: "amqp-ts" });
                 var queueName = _this._name;
                 var connection = _this._connection;
                 exports.log.log("debug", "Try to rebuild connection, before Call.", { module: "amqp-ts" });
-                connection._rebuildAll(err).then(function () {
+                return connection._rebuildAll(err).then(function () {
                     exports.log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
-                    connection._queues[queueName].publish(content, options);
+                    return connection._queues[queueName].publish(content, options);
                 });
-            }
+            });
         };
         content = Queue._packMessageContent(content, options);
         // execute sync when possible
         if (this.initialized.isFulfilled()) {
-            sendMessage();
+            return sendMessage();
         }
         else {
-            this.initialized.then(sendMessage);
+            return this.initialized.then(sendMessage);
         }
     };
     Queue.prototype.send = function (message, routingKey) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-integration": "gulp test:integration"
   },
   "dependencies": {
-    "amqplib": "^0.4.1",
+    "amqplib": "^0.5.2",
     "bluebird": "^3.3.5",
     "winston": "^2.2.0"
   },

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -314,7 +314,7 @@ export class Message {
   fields: any;
   properties: any;
 
-  _channel: AmqpLib.Channel; // for received messages only: the channel it has been received on
+  _channel: AmqpLib.ConfirmChannel; // for received messages only: the channel it has been received on
   _message: AmqpLib.Message; // received messages only: original amqplib message
 
   constructor(content?: any, options: any = {}) {
@@ -343,26 +343,33 @@ export class Message {
     return content;
   }
 
-  sendTo(destination: Exchange | Queue, routingKey: string = ""): void {
+  sendTo(destination: Exchange | Queue, routingKey: string = ""): Promise<any> {
     // inline function to send the message
     var sendMessage = () => {
-      try {
-        destination._channel.publish(exchange, routingKey, this.content, this.properties);
-      } catch (err) {
-        log.log("debug", "Publish error: " + err.message, { module: "amqp-ts" });
-        var destinationName = destination._name;
-        var connection = destination._connection;
-        log.log("debug", "Try to rebuild connection, before Call.", { module: "amqp-ts" });
-        connection._rebuildAll(err).then(() => {
-          log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
-          if (destination instanceof Queue) {
-            connection._queues[destinationName].publish(this.content, this.properties);
+      return new Promise((resolve, reject) => {
+        destination._channel.publish(exchange, routingKey, this.content, this.properties, (err, data) => {
+          if (!err) {
+            resolve(data);
           } else {
-            connection._exchanges[destinationName].publish(this.content, routingKey, this.properties);
+            reject(err);
           }
-
         });
-      }
+      })
+        .catch((err) => {
+          exports.log.log("debug", "Publish error: " + err.message, { module: "amqp-ts" });
+          var destinationName = destination._name;
+          var connection = destination._connection;
+          exports.log.log("debug", "Try to rebuild connection, before Call.", { module: "amqp-ts" });
+
+          return connection._rebuildAll(err).then(() => {
+            exports.log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
+            if (destination instanceof Queue) {
+              return connection._queues[destinationName].publish(this.content, this.properties);
+            } else {
+              return connection._exchanges[destinationName].publish(this.content, routingKey, this.properties);
+            }
+          });
+        });
     };
 
     var exchange: string;
@@ -375,9 +382,9 @@ export class Message {
 
     // execute sync when possible
     if (destination.initialized.isFulfilled()) {
-      sendMessage();
+      return sendMessage();
     } else {
-      (<Promise<any>>destination.initialized).then(sendMessage);
+      return (<Promise<any>>destination.initialized).then(sendMessage);
     }
   }
 
@@ -408,7 +415,7 @@ export class Exchange {
   initialized: Promise<Exchange.InitializeResult>;
 
   _connection: Connection;
-  _channel: AmqpLib.Channel;
+  _channel: AmqpLib.ConfirmChannel;
   _name: string;
   _type: string;
   _options: Exchange.DeclarationOptions;
@@ -435,7 +442,7 @@ export class Exchange {
   _initialize() {
     this.initialized = new Promise<Exchange.InitializeResult>((resolve, reject) => {
       this._connection.initialized.then(() => {
-        this._connection._connection.createChannel((err, channel) => {
+        this._connection._connection.createConfirmChannel((err, channel) => {
           /* istanbul ignore if */
           if (err) {
             reject(err);
@@ -466,30 +473,36 @@ export class Exchange {
   /**
    * deprecated, use 'exchange.send(message: Message)' instead
    */
-  publish(content: any, routingKey = "", options: any = {}): void {
+  publish(content: any, routingKey = "", options: any = {}): Promise<any> {
     if (typeof content === "string") {
       content = new Buffer(content);
     } else if (!(content instanceof Buffer)) {
       content = new Buffer(JSON.stringify(content));
       options.contentType = options.contentType || "application/json";
     }
-    this.initialized.then(() => {
-      try {
-        this._channel.publish(this._name, routingKey, content, options);
-      } catch (err) {
+    return this.initialized.then(() => {
+      return new Promise((resolve, reject) => {
+        this._channel.publish(this._name, routingKey, content, options, (err, data) => {
+          if (!err) {
+            resolve(data);
+          } else {
+            reject(err);
+          }
+        });
+      }).catch((err) => {
         log.log("warn", "Exchange publish error: " + err.message, { module: "amqp-ts" });
         var exchangeName = this._name;
         var connection = this._connection;
-        connection._rebuildAll(err).then(() => {
+        return connection._rebuildAll(err).then(() => {
           log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
-          connection._exchanges[exchangeName].publish(content, routingKey, options);
+          return connection._exchanges[exchangeName].publish(content, routingKey, options);
         });
-      }
+      });
     });
   }
 
-  send(message: Message, routingKey = ""): void {
-    message.sendTo(this, routingKey);
+  send(message: Message, routingKey = ""): Promise<any> {
+    return message.sendTo(this, routingKey);
   }
 
   rpc(requestParameters: any, routingKey = ""): Promise<Message> {
@@ -668,7 +681,7 @@ export class Queue {
   initialized: Promise<Queue.InitializeResult>;
 
   _connection: Connection;
-  _channel: AmqpLib.Channel;
+  _channel: AmqpLib.ConfirmChannel;
   _name: string;
   _options: Queue.DeclarationOptions;
 
@@ -697,7 +710,7 @@ export class Queue {
   _initialize(): void {
     this.initialized = new Promise<Queue.InitializeResult>((resolve, reject) => {
       this._connection.initialized.then(() => {
-        this._connection._connection.createChannel((err, channel) => {
+        this._connection._connection.createConfirmChannel((err, channel) => {
           /* istanbul ignore if */
           if (err) {
             reject(err);
@@ -749,29 +762,35 @@ export class Queue {
   /**
    * deprecated, use 'queue.send(message: Message)' instead
    */
-  publish(content: any, options: any = {}): void {
+  publish(content: any, options: any = {}): Promise<any> {
     // inline function to send the message
     var sendMessage = () => {
-      try {
-        this._channel.sendToQueue(this._name, content, options);
-      } catch (err) {
+      return new Promise((resolve, reject) => {
+        this._channel.sendToQueue(this._name, content, options, (err, data) => {
+          if (!err) {
+            resolve(data);
+          } else {
+            reject(err);
+          }
+        });
+      }).catch((err) => {
         log.log("debug", "Queue publish error: " + err.message, { module: "amqp-ts" });
         var queueName = this._name;
         var connection = this._connection;
         log.log("debug", "Try to rebuild connection, before Call.", { module: "amqp-ts" });
-        connection._rebuildAll(err).then(() => {
+        return connection._rebuildAll(err).then(() => {
           log.log("debug", "Retransmitting message.", { module: "amqp-ts" });
-          connection._queues[queueName].publish(content, options);
+          return connection._queues[queueName].publish(content, options);
         });
-      }
+      });
     };
 
     content = Queue._packMessageContent(content, options);
     // execute sync when possible
     if (this.initialized.isFulfilled()) {
-      sendMessage();
+      return sendMessage();
     } else {
-      this.initialized.then(sendMessage);
+      return this.initialized.then(sendMessage);
     }
   }
 


### PR DESCRIPTION
@alavers found the `ConfirmChannel` interface, which exposes a callback on message sending that returns only after Rabbit `ack` is complete.

Using this results in much better consistency.