### PR TITLE
Add exchange.waitForConfirms() function

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -422,6 +422,27 @@ var Exchange = (function () {
         });
         this._connection._exchanges[this._name] = this;
     };
+    Exchange.prototype.waitForConfirms = function () {
+        var channel = this._channel;
+        var waitForChannelConfirms = function () {
+            return new Promise(function (resolve, reject) {
+                channel.waitForConfirms(function (err) {
+                    if (!err) {
+                        resolve(null);
+                    }
+                    else {
+                        reject(err);
+                    }
+                });
+            });
+        };
+        if (this.initialized.isFulfilled()) {
+            return waitForChannelConfirms();
+        }
+        else {
+            return this.initialized.then(waitForChannelConfirms);
+        }
+    };
     /**
      * deprecated, use 'exchange.send(message: Message)' instead
      */

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -470,6 +470,28 @@ export class Exchange {
     this._connection._exchanges[this._name] = this;
   }
 
+  waitForConfirms() {
+    const channel = this._channel;
+
+    var waitForChannelConfirms = () => {
+      return new Promise(function (resolve, reject) {
+        channel.waitForConfirms((err) => {
+          if (!err) {
+            resolve(null);
+          } else {
+            reject(err);
+          }
+        });
+      });
+    };
+
+    if (this.initialized.isFulfilled()) {
+      return waitForChannelConfirms();
+    } else {
+      return this.initialized.then(waitForChannelConfirms);
+    }
+  }
+
   /**
    * deprecated, use 'exchange.send(message: Message)' instead
    */


### PR DESCRIPTION
This PR adds `waitForConfirm` functionality to a Rabbit exchange.