### PR TITLE
Fix reconnect behavior

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -35,6 +35,7 @@ var Connection = (function () {
         if (reconnectStrategy === void 0) { reconnectStrategy = { retries: 0, interval: 1500 }; }
         this.connectedBefore = false;
         this._rebuilding = false;
+        this._isClosing = false;
         this.url = url;
         this.socketOptions = socketOptions;
         this.reconnectStrategy = reconnectStrategy;
@@ -51,6 +52,7 @@ var Connection = (function () {
         }
         this._retry = -1;
         this._rebuilding = true;
+        this._isClosing = false;
         // rebuild the connection
         this.initialized = new Promise(function (resolve, reject) {
             _this.tryToConnect(_this, 0, function (err) {
@@ -107,7 +109,14 @@ var Connection = (function () {
                     //connection.removeListener("end", restart); // not sure this is needed
                     thisConnection._rebuildAll(err); //try to rebuild the topology when the connection  unexpectedly closes
                 };
+                var onClose = function () {
+                    connection.removeListener("close", onClose);
+                    if (!_this._isClosing) {
+                        restart(new Error("Connection closed by remote host"));
+                    }
+                };
                 connection.on("error", restart);
+                connection.on("close", onClose);
                 //connection.on("end", restart); // not sure this is needed
                 thisConnection._connection = connection;
                 callback(null);
@@ -153,6 +162,7 @@ var Connection = (function () {
     };
     Connection.prototype.close = function () {
         var _this = this;
+        this._isClosing = true;
         return new Promise(function (resolve, reject) {
             _this.initialized.then(function () {
                 _this._connection.close(function (err) {

--- a/src/amqp-ts.spec-i.ts
+++ b/src/amqp-ts.spec-i.ts
@@ -39,7 +39,12 @@ function restartAmqpServer() {
       throw (new Error("Unable to restart rabbitmq, error:\n" + err.message));
     }
   } else {
-    throw (new Error("AmqpServer shutdown and restart not implemented for this platform"));
+    try {
+      cp.execSync("./tools/restart-rabbit.sh");
+    } catch (err) {
+      winston.log("error", "Unable to shutdown and restart RabbitMQ");
+      throw (new Error("Unable to restart rabbitmq, error:\n" + err.message));
+    }
   }
 }
 

--- a/tools/restart-rabbit.sh
+++ b/tools/restart-rabbit.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+container_id=`docker ps -q --filter ancestor=rabbit`
+docker exec $container_id rabbitmqctl stop_app
+docker exec $container_id rabbitmqctl start_app


### PR DESCRIPTION
Fixes a bug where amqp-ts would fail to reconnect in the event that a
node in a RabbitMQ cluster was cycled. In this case, amqplib emits a
close event which amqp-ts fails to listen for. Fixes
abreits#27