### PR TITLE
Fix double restart bug

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -111,7 +111,7 @@ var Connection = (function () {
                 };
                 var onClose = function () {
                     connection.removeListener("close", onClose);
-                    if (!_this._isClosing) {
+                    if (!thisConnection._rebuilding && !thisConnection._isClosing) {
                         restart(new Error("Connection closed by remote host"));
                     }
                 };

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -134,7 +134,7 @@ export class Connection {
         };
         var onClose = () => {
           connection.removeListener("close", onClose);
-          if (!this._isClosing) {
+          if (!thisConnection._rebuilding && !thisConnection._isClosing) {
             restart(new Error("Connection closed by remote host"));
           }
         };


### PR DESCRIPTION
Fixes a minor connection recovery bug introduced in [#29](https://github.com/abreits/amqp-ts/pull/29) in which restart
woud be invoked twice. The close event handler will no longer trigger a
rebuild if a prior error has already toggled _rebuilding to true.