### PR TITLE
Add log on channel creation

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -405,9 +405,11 @@ var Exchange = (function () {
                 _this._connection._connection.createConfirmChannel(function (err, channel) {
                     /* istanbul ignore if */
                     if (err) {
+                        exports.log.log("error", "Failed on channel creation.", { module: "amqp-ts" });
                         reject(err);
                     }
                     else {
+                        exports.log.log("info", "Channel created.", { module: "amqp-ts" });
                         _this._channel = channel;
                         var callback = function (err, ok) {
                             /* istanbul ignore if */
@@ -682,9 +684,11 @@ var Queue = (function () {
                 _this._connection._connection.createConfirmChannel(function (err, channel) {
                     /* istanbul ignore if */
                     if (err) {
+                        exports.log.log("error", "Failed on channel creation.", { module: "amqp-ts" });
                         reject(err);
                     }
                     else {
+                        exports.log.log("info", "Channel created.", { module: "amqp-ts" });
                         _this._channel = channel;
                         var callback = function (err, ok) {
                             /* istanbul ignore if */

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -548,6 +548,7 @@ var Exchange = (function () {
                                     reject(err);
                                 }
                                 else {
+                                    exports.log.log("info", "Channel closed.", { module: "amqp-ts" });
                                     delete _this._channel;
                                     delete _this._connection;
                                     resolve(null);
@@ -577,6 +578,7 @@ var Exchange = (function () {
                             reject(err);
                         }
                         else {
+                            exports.log.log("info", "Channel closed.", { module: "amqp-ts" });
                             delete _this._channel;
                             delete _this._connection;
                             resolve(null);
@@ -999,6 +1001,7 @@ var Queue = (function () {
                                     reject(err);
                                 }
                                 else {
+                                    exports.log.log("info", "Channel closed.", { module: "amqp-ts" });
                                     delete _this._channel;
                                     delete _this._connection;
                                     resolve(ok);
@@ -1030,6 +1033,7 @@ var Queue = (function () {
                             reject(err);
                         }
                         else {
+                            exports.log.log("info", "Channel closed.", { module: "amqp-ts" });
                             delete _this._channel;
                             delete _this._connection;
                             resolve(null);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -588,6 +588,7 @@ export class Exchange {
                 if (err) {
                   reject(err);
                 } else {
+                  log.log("info", "Channel closed.", { module: "amqp-ts" });
                   delete this._channel;
                   delete this._connection;
                   resolve(null);
@@ -616,6 +617,7 @@ export class Exchange {
             if (err) {
               reject(err);
             } else {
+              log.log("info", "Channel closed.", { module: "amqp-ts" });
               delete this._channel;
               delete this._connection;
               resolve(null);
@@ -1060,6 +1062,7 @@ export class Queue {
                 if (err) {
                   reject(err);
                 } else {
+                  log.log("info", "Channel closed.", { module: "amqp-ts" });
                   delete this._channel;
                   delete this._connection;
                   resolve(<Queue.DeleteResult>ok);
@@ -1090,6 +1093,7 @@ export class Queue {
             if (err) {
               reject(err);
             } else {
+              log.log("info", "Channel closed.", { module: "amqp-ts" });
               delete this._channel;
               delete this._connection;
               resolve(null);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -455,8 +455,10 @@ export class Exchange {
         this._connection._connection.createConfirmChannel((err, channel) => {
           /* istanbul ignore if */
           if (err) {
+	    log.log("error", "Failed on channel creation.", { module: "amqp-ts" });
             reject(err);
           } else {
+	    log.log("info", "Channel created.", { module: "amqp-ts" });
             this._channel = channel;
             let callback = (err, ok) => {
               /* istanbul ignore if */
@@ -745,8 +747,10 @@ export class Queue {
         this._connection._connection.createConfirmChannel((err, channel) => {
           /* istanbul ignore if */
           if (err) {
+	    log.log("error", "Failed on channel creation.", { module: "amqp-ts" });
             reject(err);
           } else {
+	    log.log("info", "Channel created.", { module: "amqp-ts" });
             this._channel = channel;
             let callback = (err, ok) => {
               /* istanbul ignore if */


### PR DESCRIPTION
**Changes**

Adding logs on channel creation and channel creation failure. It will help to create metric based on logs on channel creation.

Note: Reason why I added logs instead of dd metrics was dd stats was not accessible amqp-ts to catch channel creation event.

The idea here will be to build metric on top of this new logs from a rabbitmq client perspective. 

See [SCALEWA-2846](https://zendesk.atlassian.net/browse/SCALEWA-2846)