### PR TITLE
Throw an exception when the channel is canceled.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,7 +93,7 @@ gulp.task('lint', function () {
 
 
 // unit tests, more a fast integration test because at the moment it uses an external AMQP server
-gulp.task('test', gulp.series('copy-to-lib'), function () {
+gulp.task('test', gulp.series('copy-to-lib', function () {
   return gulp.src('transpiled/**/*.spec.js', {
     read: false
   })
@@ -102,10 +102,10 @@ gulp.task('test', gulp.series('copy-to-lib'), function () {
       reporter: 'spec' // 'spec', 'dot'
     }))
     .on('error', swallowError);
-});
+}));
 
 // unit tests, more a fast integration test because at the moment it uses an external AMQP server
-gulp.task('test:dot', gulp.series('copy-to-lib'), function () {
+gulp.task('test:dot', gulp.series('copy-to-lib', function () {
   return gulp.src('transpiled/**/*.spec.js', {
     read: false
   })
@@ -114,10 +114,10 @@ gulp.task('test:dot', gulp.series('copy-to-lib'), function () {
       reporter: 'dot' // 'spec', 'dot'
     }))
     .on('error', swallowError);
-});
+}));
 
 // integration tests, at the moment more an extended version of the unit tests
-gulp.task('test:integration', gulp.series('copy-to-lib'), function () {
+gulp.task('test:integration', gulp.series('copy-to-lib', function () {
   return gulp.src('transpiled/**/*.spec-i.js', {
     read: false
   })
@@ -125,9 +125,9 @@ gulp.task('test:integration', gulp.series('copy-to-lib'), function () {
       reporter: 'dot' // 'spec', 'dot'
     }))
     .on('error', swallowError);
-});
+}));
 
-gulp.task('test:coverage', gulp.series('copy-to-lib'), function () {
+gulp.task('test:coverage', gulp.series('copy-to-lib', function () {
   return gulp.src('transpiled/**/*.spec.js', {
     read: false
   })
@@ -135,7 +135,7 @@ gulp.task('test:coverage', gulp.series('copy-to-lib'), function () {
       reporter: 'spec', // 'spec', 'dot'
       istanbul: true
     }));
-});
+}));
 
 
 // quick fix for gulp 4, migrating from gulp 3, fixing 'task never defined' errors

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -970,7 +970,7 @@ var Queue = /** @class */ (function () {
                  * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
                  *     https://www.rabbitmq.com/consumer-cancel.html
                  */
-                exports.log.error("Queue.onMessage - Message is null. Channel has been canceled.");
+                exports.log.error("activateConsumerWrapper - Message is null. Channel has been canceled.");
                 throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
             }
             try {

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -970,7 +970,7 @@ var Queue = /** @class */ (function () {
                  * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
                  *     https://www.rabbitmq.com/consumer-cancel.html
                  */
-                exports.log.error("activateConsumerWrapper - Message is null. Channel has been canceled.");
+                exports.log.warn("activateConsumerWrapper - Message is null. Channel has been canceled.");
                 throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
             }
             try {

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -966,12 +966,11 @@ var Queue = /** @class */ (function () {
         var activateConsumerWrapper = function (msg) {
             if (!msg) {
                 /* basic.cancel is triggered on queue deletion if connection is not closed, it will dispatch an empty msg.
-                 * Connection needs to be rebuilt in that case.
+                 * Throw an exception so that the system is notified.
                  * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
                  *     https://www.rabbitmq.com/consumer-cancel.html
                  */
-                _this._connection._rebuildAll(new Error("Channel cancelled"));
-                return;
+                throw new Error('activateConsumerWrapper - Message is null. Channel has been canceled.');
             }
             try {
                 var message = new Message(msg.content, msg.properties);

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -970,7 +970,8 @@ var Queue = /** @class */ (function () {
                  * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
                  *     https://www.rabbitmq.com/consumer-cancel.html
                  */
-                throw new Error('activateConsumerWrapper - Message is null. Channel has been canceled.');
+                exports.log.error("Queue.onMessage - Message is null. Channel has been canceled.");
+                throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
             }
             try {
                 var message = new Message(msg.content, msg.properties);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -1033,8 +1033,9 @@ export class Queue {
          * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
          *     https://www.rabbitmq.com/consumer-cancel.html
          */
-      throw new Error('activateConsumerWrapper - Message is null. Channel has been canceled.');
-    }
+        log.error("Queue.onMessage - Message is null. Channel has been canceled.");
+        throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
+      }
 
       try {
         var message = new Message(msg.content, msg.properties);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -1029,13 +1029,12 @@ export class Queue {
     var activateConsumerWrapper = (msg: AmqpLib.Message) => {
       if (!msg) {
         /* basic.cancel is triggered on queue deletion if connection is not closed, it will dispatch an empty msg.
-         * Connection needs to be rebuilt in that case.
+         * Throw an exception so that the system is notified.
          * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
          *     https://www.rabbitmq.com/consumer-cancel.html
          */
-        this._connection._rebuildAll(new Error("Channel cancelled"));
-        return;
-      }
+      throw new Error('activateConsumerWrapper - Message is null. Channel has been canceled.');
+    }
 
       try {
         var message = new Message(msg.content, msg.properties);

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -1033,7 +1033,7 @@ export class Queue {
          * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
          *     https://www.rabbitmq.com/consumer-cancel.html
          */
-        log.error("Queue.onMessage - Message is null. Channel has been canceled.");
+        log.error("activateConsumerWrapper - Message is null. Channel has been canceled.");
         throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
       }
 

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -1033,7 +1033,7 @@ export class Queue {
          * See https://github.com/amqp-node/amqplib/blob/v0.10.3/lib/channel.js#L495-L499
          *     https://www.rabbitmq.com/consumer-cancel.html
          */
-        log.error("activateConsumerWrapper - Message is null. Channel has been canceled.");
+        log.warn("activateConsumerWrapper - Message is null. Channel has been canceled.");
         throw new Error("activateConsumerWrapper - Message is null. Channel has been canceled.");
       }
 


### PR DESCRIPTION
**Changes**

On empty error, it seems that throwing an error trigger the rebuild logic and create the expected reconnection for all the consumers. 

Previous fix, when calling explicitly rebuildAll seems to create unexpected consumers on all the queues that use this same connection without closing the old ones. It created orphan consumers :(.

https://zendesk.slack.com/archives/C04383854TZ/p1677254064050979?thread_ts=1677252708.019759&cid=C04383854TZ
