### PR TITLE
Remove message retransmission on reconnect

### DIFF
--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -384,7 +384,7 @@ var Message = /** @class */ (function () {
             return sendMessage();
         }
         else {
-            return destination.initialized.then(sendMessage);
+            return Promise.reject(new Error("Connection is not ready."));
         }
     };
     Message.prototype.ack = function (allUpTo) {
@@ -825,7 +825,7 @@ var Queue = /** @class */ (function () {
             return sendMessage();
         }
         else {
-            return this.initialized.then(sendMessage);
+            return Promise.reject(new Error("Connection is not ready."));
         }
     };
     Queue.prototype.send = function (message) {

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -366,8 +366,8 @@ var Message = /** @class */ (function () {
                 var connection = destination._connection;
                 exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-                    return Promise.resolve();
+                    exports.log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.reject(error);
                 });
             });
         };
@@ -521,8 +521,8 @@ var Exchange = /** @class */ (function () {
                 exports.log.warn("Exchange publish error: " + error.message, { module: "amqp-ts", error: error });
                 var connection = _this._connection;
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-                    return Promise.resolve();
+                    exports.log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.reject(error);
                 });
             });
         });
@@ -814,8 +814,8 @@ var Queue = /** @class */ (function () {
                 var connection = _this._connection;
                 exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-                    return Promise.resolve();
+                    exports.log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.reject(error);
                 });
             });
         };

--- a/lib/amqp-ts.js
+++ b/lib/amqp-ts.js
@@ -363,17 +363,11 @@ var Message = /** @class */ (function () {
             })
                 .catch(function (error) {
                 exports.log.debug("Publish error: " + error.message, { module: "amqp-ts", error: error });
-                var destinationName = destination._name;
                 var connection = destination._connection;
                 exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.debug("Retransmitting message.", { module: "amqp-ts" });
-                    if (destination instanceof Queue) {
-                        return connection._queues[destinationName].publish(_this.content, _this.properties);
-                    }
-                    else {
-                        return connection._exchanges[destinationName].publish(_this.content, routingKey, _this.properties);
-                    }
+                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.resolve();
                 });
             });
         };
@@ -525,11 +519,10 @@ var Exchange = /** @class */ (function () {
                 });
             }).catch(function (error) {
                 exports.log.warn("Exchange publish error: " + error.message, { module: "amqp-ts", error: error });
-                var exchangeName = _this._name;
                 var connection = _this._connection;
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.debug("Retransmitting message.", { module: "amqp-ts" });
-                    return connection._exchanges[exchangeName].publish(content, routingKey, options);
+                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.resolve();
                 });
             });
         });
@@ -818,12 +811,11 @@ var Queue = /** @class */ (function () {
                 });
             }).catch(function (error) {
                 exports.log.debug("Queue publish error: " + error.message, { module: "amqp-ts", error: error });
-                var queueName = _this._name;
                 var connection = _this._connection;
                 exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
                 return connection._rebuildAll(error).then(function () {
-                    exports.log.debug("Retransmitting message.", { module: "amqp-ts" });
-                    return connection._queues[queueName].publish(content, options);
+                    exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+                    return Promise.resolve();
                 });
             });
         };

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -420,7 +420,7 @@ export class Message {
     if (destination.initialized.isFulfilled()) {
       return sendMessage();
     } else {
-      return (<Promise<any>>destination.initialized).then(sendMessage);
+      return Promise.reject(new Error("Connection is not ready."));
     }
   }
 
@@ -882,7 +882,7 @@ export class Queue {
     if (this.initialized.isFulfilled()) {
       return sendMessage();
     } else {
-      return this.initialized.then(sendMessage);
+      return Promise.reject(new Error("Connection is not ready."));
     }
   }
 

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -402,8 +402,8 @@ export class Message {
           exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
 
           return connection._rebuildAll(error).then(() => {
-            exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-            return Promise.resolve();
+            exports.log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+            return Promise.reject(error);
           });
         });
     };
@@ -558,8 +558,8 @@ export class Exchange {
         log.warn("Exchange publish error: " + error.message, { module: "amqp-ts", error });
         var connection = this._connection;
         return connection._rebuildAll(error).then(() => {
-          log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-          return Promise.resolve();
+          log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+          return Promise.reject(error);
         });
       });
     });
@@ -871,8 +871,8 @@ export class Queue {
         var connection = this._connection;
         log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
         return connection._rebuildAll(error).then(() => {
-          log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-          return Promise.resolve();
+          log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+          return Promise.reject(error);
         });
       });
     };

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -401,10 +401,10 @@ export class Message {
           var connection = destination._connection;
           exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
 
-          return connection._rebuildAll(error).then(() => {
+          connection._rebuildAll(error).then(() => {
             exports.log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-            return Promise.reject(error);
           });
+          return Promise.reject(error);
         });
     };
 
@@ -557,10 +557,10 @@ export class Exchange {
       }).catch((error) => {
         log.warn("Exchange publish error: " + error.message, { module: "amqp-ts", error });
         var connection = this._connection;
-        return connection._rebuildAll(error).then(() => {
+        connection._rebuildAll(error).then(() => {
           log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-          return Promise.reject(error);
         });
+        return Promise.reject(error);
       });
     });
   }
@@ -870,10 +870,10 @@ export class Queue {
         log.debug( "Queue publish error: " + error.message, { module: "amqp-ts", error });
         var connection = this._connection;
         log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
-        return connection._rebuildAll(error).then(() => {
+        connection._rebuildAll(error).then(() => {
           log.warn("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
-          return Promise.reject(error);
         });
+        return Promise.reject(error);
       });
     };
 

--- a/src/amqp-ts.ts
+++ b/src/amqp-ts.ts
@@ -398,17 +398,12 @@ export class Message {
       })
         .catch((error) => {
           exports.log.debug("Publish error: " + error.message, { module: "amqp-ts", error });
-          var destinationName = destination._name;
           var connection = destination._connection;
           exports.log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
 
           return connection._rebuildAll(error).then(() => {
-            exports.log.debug("Retransmitting message.", { module: "amqp-ts" });
-            if (destination instanceof Queue) {
-              return connection._queues[destinationName].publish(this.content, this.properties);
-            } else {
-              return connection._exchanges[destinationName].publish(this.content, routingKey, this.properties);
-            }
+            exports.log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+            return Promise.resolve();
           });
         });
     };
@@ -561,11 +556,10 @@ export class Exchange {
         });
       }).catch((error) => {
         log.warn("Exchange publish error: " + error.message, { module: "amqp-ts", error });
-        var exchangeName = this._name;
         var connection = this._connection;
         return connection._rebuildAll(error).then(() => {
-          log.debug("Retransmitting message.", { module: "amqp-ts" });
-          return connection._exchanges[exchangeName].publish(content, routingKey, options);
+          log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+          return Promise.resolve();
         });
       });
     });
@@ -874,12 +868,11 @@ export class Queue {
         });
       }).catch((error) => {
         log.debug( "Queue publish error: " + error.message, { module: "amqp-ts", error });
-        var queueName = this._name;
         var connection = this._connection;
         log.debug("Try to rebuild connection, before Call.", { module: "amqp-ts" });
         return connection._rebuildAll(error).then(() => {
-          log.debug("Retransmitting message.", { module: "amqp-ts" });
-          return connection._queues[queueName].publish(content, options);
+          log.info("Connection rebuilt, NOT retransmitting message.", { module: "amqp-ts" });
+          return Promise.resolve();
         });
       });
     };


### PR DESCRIPTION
Since we are moving our retry strategy to SQS, we want to disable the in-flight message retry that's currently in-memory.

- Added info log when this case is happening to have a sense of how amqp-ts was retrying the message before we moved to SQS